### PR TITLE
Fixed warnings in Unity 5.5 (new texture importer)

### DIFF
--- a/Assets/kode80/Clouds/Scripts/EditorState.cs
+++ b/Assets/kode80/Clouds/Scripts/EditorState.cs
@@ -248,10 +248,16 @@ namespace kode80.Clouds
                 AssetDatabase.Refresh();
                 
                 TextureImporter importer = AssetImporter.GetAtPath(path) as TextureImporter;
+#if UNITY_5_5_OR_NEWER
+                importer.textureType = TextureImporterType.Default;
+                importer.sRGBTexture = false;
+                importer.textureCompression = TextureImporterCompression.Uncompressed;
+#else
                 importer.textureType = TextureImporterType.Advanced;
                 importer.generateMipsInLinearSpace = true;
                 importer.linearTexture = true;
                 importer.textureFormat = TextureImporterFormat.AutomaticTruecolor;
+#endif
                 importer.SaveAndReimport();
 
 				AssetDatabase.Refresh();


### PR DESCRIPTION
The texture importer in Unity 5.5 (currently in beta) got a big refactor. This PR fixes a bunch of warnings.

Also, in case you're wondering why `importer.generateMipsInLinearSpace = true;` is missing from the 5.5 code path, it's been removed (mipmaps are always generated in linear space).