### PR TITLE
CPU & GC optimizations

### DIFF
--- a/Assets/kode80/Clouds/Scripts/CrepuscularRays.cs
+++ b/Assets/kode80/Clouds/Scripts/CrepuscularRays.cs
@@ -1,4 +1,4 @@
-﻿//***************************************************
+//***************************************************
 //
 //  Author: Ben Hopkins
 //  Copyright (C) 2016 kode80 LLC, 
@@ -14,7 +14,6 @@
 //***************************************************
 
 using UnityEngine;
-using System.Collections;
 
 namespace kode80.Clouds
 {
@@ -22,18 +21,17 @@ namespace kode80.Clouds
 	public class CrepuscularRays : MonoBehaviour 
 	{
 		public kode80Clouds clouds;
-        public float sampleCount = 20.0f;
-        [Range( 0.0f, 1.0f)]
-        public float density = 0.813f;
-        [Range(0.0f, 1.0f)]
-        public float decay = 1.0f;
-        [Range(0.0f, 1.0f)]
-        public float weight = 1.0f;
-        public float exposure = 3.0f;
+		public float sampleCount = 20.0f;
+		[Range( 0.0f, 1.0f)]
+		public float density = 0.813f;
+		[Range(0.0f, 1.0f)]
+		public float decay = 1.0f;
+		[Range(0.0f, 1.0f)]
+		public float weight = 1.0f;
+		public float exposure = 3.0f;
 
-        private Material _material;
+		private Material _material;
 
-		
 		void OnEnable()
 		{
 			CreateMaterialsIfNeeded();
@@ -52,20 +50,15 @@ namespace kode80.Clouds
 		void Start () 
 		{
 			CreateMaterialsIfNeeded();
-            clouds = GameObject.FindObjectOfType<kode80Clouds>();
-		}
-		
-		// Update is called once per frame
-		void Update () {
-		
+			clouds = GameObject.FindObjectOfType<kode80Clouds>();
 		}
 
 		public void OnRenderImage( RenderTexture src, RenderTexture dst)
 		{
-            if( clouds == null) {
-                Graphics.Blit(src, dst);
-                return;
-            }
+			if( clouds == null) {
+				Graphics.Blit(src, dst);
+				return;
+			}
 
 			CreateMaterialsIfNeeded();
 
@@ -73,18 +66,18 @@ namespace kode80.Clouds
 			sunScreenSpace.x /= clouds.targetCamera.pixelWidth;
 			sunScreenSpace.y /= clouds.targetCamera.pixelHeight;
 
-			_material.SetTexture( "_Clouds", clouds.currentFrame);
-            _material.SetVector("_SunScreenSpace", sunScreenSpace);
-            _material.SetFloat("_SampleCount", sampleCount);
-            _material.SetFloat("_Density", density);
-            _material.SetFloat("_Decay", decay);
-            _material.SetFloat("_Weight", weight);
-            _material.SetFloat("_Exposure", exposure);
+			_material.SetTexture(Uniforms._Clouds, clouds.currentFrame);
+			_material.SetVector(Uniforms._SunScreenSpace, sunScreenSpace);
+			_material.SetFloat(Uniforms._SampleCount, sampleCount);
+			_material.SetFloat(Uniforms._Density, density);
+			_material.SetFloat(Uniforms._Decay, decay);
+			_material.SetFloat(Uniforms._Weight, weight);
+			_material.SetFloat(Uniforms._Exposure, exposure);
 
-            Graphics.Blit( src, dst, _material);
-        }
+			Graphics.Blit( src, dst, _material);
+		}
 
-        private void CreateMaterialsIfNeeded()
+		private void CreateMaterialsIfNeeded()
 		{
 			if( _material == null)
 			{

--- a/Assets/kode80/Clouds/Scripts/FullScreenQuad.cs
+++ b/Assets/kode80/Clouds/Scripts/FullScreenQuad.cs
@@ -1,4 +1,4 @@
-﻿//***************************************************
+//***************************************************
 //
 //  Author: Ben Hopkins
 //  Copyright (C) 2016 kode80 LLC, 
@@ -27,13 +27,23 @@ namespace kode80.Clouds
 		public Material material;
 		private MeshFilter _meshFilter;
 		private MeshRenderer _meshRenderer;
-
+		private Mesh _mesh;
+		private readonly Vector3[] _vertices = new Vector3[4];
+		private readonly Vector2[] _uvs = new [] { Vector2.zero, Vector2.right, Vector2.one, Vector2.up };
+		private readonly int[] _triangles = new [] { 0, 1, 2, 2, 3, 0};
 
 		void Awake()
 		{
 			targetCamera = targetCamera == null ? Camera.main : targetCamera;
 			_meshFilter = GetOrAddComponent<MeshFilter>(gameObject);
 			_meshRenderer = GetOrAddComponent<MeshRenderer>(gameObject);
+
+			_mesh = new Mesh();
+			_mesh.name = "Cloud Quad";
+			_mesh.MarkDynamic();
+			_mesh.vertices = _vertices;
+			_mesh.uv = _uvs;
+			_mesh.triangles = _triangles;
 
 			GenerateMesh(targetCamera);
 		}
@@ -59,25 +69,16 @@ namespace kode80.Clouds
 			h *= verticalScale;
 
 			float z = localZOffset;
-			Vector3 v0 = new Vector3(-w, -h, z);
-			Vector3 v1 = new Vector3(w, -h, z);
-			Vector3 v2 = new Vector3(w, h, z);
-			Vector3 v3 = new Vector3(-w, h, z);
+			_vertices[0] = new Vector3(-w, -h, z);
+			_vertices[1] = new Vector3(w, -h, z);
+			_vertices[2] = new Vector3(w, h, z);
+			_vertices[3] = new Vector3(-w, h, z);
 
-			Vector2 uv0 = new Vector2(0.0f, 0.0f);
-			Vector2 uv1 = new Vector2(1.0f, 0.0f);
-			Vector2 uv2 = new Vector2(1.0f, 1.0f);
-			Vector2 uv3 = new Vector2(0.0f, 1.0f);
+			_mesh.vertices = _vertices;
+			_mesh.RecalculateBounds();
+			_mesh.UploadMeshData(false);
 
-			Mesh mesh = new Mesh();
-			mesh.vertices = new Vector3[] { v0, v1, v2, v3 };
-			mesh.uv = new Vector2[] { uv0, uv1, uv2, uv3 };
-			mesh.triangles = new int[] { 0, 1, 2,
-				2, 3, 0};
-			mesh.RecalculateBounds();
-			mesh.UploadMeshData( true);
-
-			_meshFilter.sharedMesh = mesh;
+			_meshFilter.sharedMesh = _mesh;
 			_meshRenderer.sharedMaterial = material;
 		}
 

--- a/Assets/kode80/Clouds/Scripts/SharedProperties.cs
+++ b/Assets/kode80/Clouds/Scripts/SharedProperties.cs
@@ -1,4 +1,4 @@
-﻿//***************************************************
+//***************************************************
 //
 //  Author: Ben Hopkins
 //  Copyright (C) 2016 kode80 LLC, 
@@ -141,24 +141,24 @@ namespace kode80.Clouds
 			Matrix4x4 inverseProjection = projection.inverse;
 			if( jitterProjection) { inverseProjection *= jitter; }
 
-			material.SetFloat( "_EarthRadius", earthRadius);
-			material.SetFloat( "_StartHeight", atmosphereStartHeight);
-			material.SetFloat( "_EndHeight", atmosphereEndHeight);
-			material.SetFloat( "_AtmosphereThickness", atmosphereEndHeight - atmosphereStartHeight);
-			material.SetVector( "_CameraPosition", cameraPosition);
-			material.SetFloat( "_MaxDistance", maxDistance);
-			material.SetMatrix( "_PreviousProjection", previousProjection);
-			material.SetMatrix( "_PreviousInverseProjection", previousProjection.inverse);
-			material.SetMatrix( "_PreviousRotation", previousRotation);
-			material.SetMatrix( "_PreviousInverseRotation", previousInverseRotation);
-			material.SetMatrix( "_Projection", projection);
-			material.SetMatrix( "_InverseProjection", inverseProjection);
-			material.SetMatrix( "_Rotation", rotation);
-			material.SetMatrix( "_InverseRotation", inverseRotation);
-			material.SetFloat( "_SubFrameNumber", subFrameNumber);
-			material.SetFloat( "_SubPixelSize", subPixelSize);
-			material.SetVector( "_SubFrameSize", new Vector2( _subFrameWidth, _subFrameHeight));
-			material.SetVector( "_FrameSize", new Vector2( _frameWidth, _frameHeight));
+			material.SetFloat(Uniforms._EarthRadius, earthRadius);
+			material.SetFloat(Uniforms._StartHeight, atmosphereStartHeight);
+			material.SetFloat(Uniforms._EndHeight, atmosphereEndHeight);
+			material.SetFloat(Uniforms._AtmosphereThickness, atmosphereEndHeight - atmosphereStartHeight);
+			material.SetVector(Uniforms._CameraPosition, cameraPosition);
+			material.SetFloat(Uniforms._MaxDistance, maxDistance);
+			material.SetMatrix(Uniforms._PreviousProjection, previousProjection);
+			material.SetMatrix(Uniforms._PreviousInverseProjection, previousProjection.inverse);
+			material.SetMatrix(Uniforms._PreviousRotation, previousRotation);
+			material.SetMatrix(Uniforms._PreviousInverseRotation, previousInverseRotation);
+			material.SetMatrix(Uniforms._Projection, projection);
+			material.SetMatrix(Uniforms._InverseProjection, inverseProjection);
+			material.SetMatrix(Uniforms._Rotation, rotation);
+			material.SetMatrix(Uniforms._InverseRotation, inverseRotation);
+			material.SetFloat(Uniforms._SubFrameNumber, subFrameNumber);
+			material.SetFloat(Uniforms._SubPixelSize, subPixelSize);
+			material.SetVector(Uniforms._SubFrameSize, new Vector2( _subFrameWidth, _subFrameHeight));
+			material.SetVector(Uniforms._FrameSize, new Vector2( _frameWidth, _frameHeight));
 		}
 		
 		public Vector3 NormalizedPointToAtmosphere( Vector2 point, Camera theCamera)

--- a/Assets/kode80/Clouds/Scripts/TexturePainter.cs
+++ b/Assets/kode80/Clouds/Scripts/TexturePainter.cs
@@ -1,4 +1,4 @@
-﻿//***************************************************
+//***************************************************
 //
 //  Author: Ben Hopkins
 //  Copyright (C) 2016 kode80 LLC, 
@@ -60,18 +60,18 @@ namespace kode80.Clouds
 			float w = radius;
 			float z = 0.0f;
 
-			_material.SetTexture( "_MainTex", target);
-			_material.SetFloat( "_CoverageOpacity", coverageOpacity);
-			_material.SetFloat( "_TypeOpacity", typeOpacity);
-			_material.SetFloat( "_ShouldDrawCoverage", drawCoverage ? 1.0f : 0.0f);
-			_material.SetFloat( "_ShouldDrawType", drawType ? 1.0f : 0.0f);
-			_material.SetFloat( "_ShouldBlendValues", blendValues ? 1.0f : 0.0f);
+			_material.SetTexture(Uniforms._MainTex, target);
+			_material.SetFloat(Uniforms._CoverageOpacity, coverageOpacity);
+			_material.SetFloat(Uniforms._TypeOpacity, typeOpacity);
+			_material.SetFloat(Uniforms._ShouldDrawCoverage, drawCoverage ? 1.0f : 0.0f);
+			_material.SetFloat(Uniforms._ShouldDrawType, drawType ? 1.0f : 0.0f);
+			_material.SetFloat(Uniforms._ShouldBlendValues, blendValues ? 1.0f : 0.0f);
 
 			if( brushTexture != null)
 			{
-				_material.SetTexture( "_BrushTexture", brushTexture);
+				_material.SetTexture(Uniforms._BrushTexture, brushTexture);
 			}
-			_material.SetFloat( "_BrushTextureAlpha", brushTexture == null ? 0.0f : 1.0f);
+			_material.SetFloat(Uniforms._BrushTextureAlpha, brushTexture == null ? 0.0f : 1.0f);
 
 			GL.PushMatrix();
 			_material.SetPass( 0);

--- a/Assets/kode80/Clouds/Scripts/TimeOfDay.cs
+++ b/Assets/kode80/Clouds/Scripts/TimeOfDay.cs
@@ -1,4 +1,4 @@
-﻿//***************************************************
+//***************************************************
 //
 //  Author: Ben Hopkins
 //  Copyright (C) 2016 kode80 LLC, 
@@ -49,7 +49,7 @@ namespace kode80.Clouds
 			TimeOfDayKeyFrame keyFrameA = KeyFrameBelowAngle( angle);
 			TimeOfDayKeyFrame keyFrameB = KeyFrameAboveAngle( angle);
 			float delta = keyFrameB.angle - keyFrameA.angle;
-			float alpha = delta == 0.0f ? 0.5f : (angle - keyFrameA.angle) / delta;
+			float alpha = Mathf.Approximately(delta, 0.0f) ? 0.5f : (angle - keyFrameA.angle) / delta;
 
 			UnityEngine.RenderSettings.fogColor = Color.Lerp( keyFrameA.fogColor, keyFrameB.fogColor, alpha);
 
@@ -66,9 +66,9 @@ namespace kode80.Clouds
 
 			if( proceduralSkybox)
 			{
-				proceduralSkybox.SetFloat( "_SunSize", Mathf.Lerp( keyFrameA.sunSize, 
+				proceduralSkybox.SetFloat(Uniforms._SunSize, Mathf.Lerp( keyFrameA.sunSize, 
 				                                                   keyFrameB.sunSize, alpha));
-				proceduralSkybox.SetFloat( "_AtmosphereThickness", Mathf.Lerp( keyFrameA.atmosphereThickness, 
+				proceduralSkybox.SetFloat(Uniforms._AtmosphereThickness, Mathf.Lerp( keyFrameA.atmosphereThickness, 
 				                                                               keyFrameB.atmosphereThickness, alpha));
 			}
 		}

--- a/Assets/kode80/Clouds/Scripts/Uniforms.cs
+++ b/Assets/kode80/Clouds/Scripts/Uniforms.cs
@@ -1,0 +1,102 @@
+using UnityEngine;
+
+namespace kode80.Clouds
+{
+    internal static class Uniforms
+    {
+        internal static readonly int _CloudBottomFade = Shader.PropertyToID("_CloudBottomFade");
+        internal static readonly int _MaxIterations = Shader.PropertyToID("_MaxIterations");
+        internal static readonly int _SampleScalar = Shader.PropertyToID("_SampleScalar");
+        internal static readonly int _SampleThreshold = Shader.PropertyToID("_SampleThreshold");
+        internal static readonly int _LODDistance = Shader.PropertyToID("_LODDistance");
+        internal static readonly int _RayMinimumY = Shader.PropertyToID("_RayMinimumY");
+        internal static readonly int _DetailScale = Shader.PropertyToID("_DetailScale");
+        internal static readonly int _ErosionEdgeSize = Shader.PropertyToID("_ErosionEdgeSize");
+        internal static readonly int _CloudDistortion = Shader.PropertyToID("_CloudDistortion");
+        internal static readonly int _CloudDistortionScale = Shader.PropertyToID("_CloudDistortionScale");
+        internal static readonly int _HorizonFadeScalar = Shader.PropertyToID("_HorizonFadeScalar");
+        internal static readonly int _HorizonFadeStartAlpha = Shader.PropertyToID("_HorizonFadeStartAlpha");
+        internal static readonly int _OneMinusHorizonFadeStartAlpha = Shader.PropertyToID("_OneMinusHorizonFadeStartAlpha");
+        internal static readonly int _Perlin3D = Shader.PropertyToID("_Perlin3D");
+        internal static readonly int _Detail3D = Shader.PropertyToID("_Detail3D");
+        internal static readonly int _BaseOffset = Shader.PropertyToID("_BaseOffset");
+        internal static readonly int _DetailOffset = Shader.PropertyToID("_DetailOffset");
+        internal static readonly int _BaseScale = Shader.PropertyToID("_BaseScale");
+        internal static readonly int _LightScalar = Shader.PropertyToID("_LightScalar");
+        internal static readonly int _AmbientScalar = Shader.PropertyToID("_AmbientScalar");
+        internal static readonly int _CloudHeightGradient1 = Shader.PropertyToID("_CloudHeightGradient1");
+        internal static readonly int _CloudHeightGradient2 = Shader.PropertyToID("_CloudHeightGradient2");
+        internal static readonly int _CloudHeightGradient3 = Shader.PropertyToID("_CloudHeightGradient3");
+        internal static readonly int _Coverage = Shader.PropertyToID("_Coverage");
+        internal static readonly int _LightDirection = Shader.PropertyToID("_LightDirection");
+        internal static readonly int _LightColor = Shader.PropertyToID("_LightColor");
+        internal static readonly int _CloudBaseColor = Shader.PropertyToID("_CloudBaseColor");
+        internal static readonly int _CloudTopColor = Shader.PropertyToID("_CloudTopColor");
+        internal static readonly int _HorizonCoverageStart = Shader.PropertyToID("_HorizonCoverageStart");
+        internal static readonly int _HorizonCoverageEnd = Shader.PropertyToID("_HorizonCoverageEnd");
+        internal static readonly int _Density = Shader.PropertyToID("_Density");
+        internal static readonly int _ForwardScatteringG = Shader.PropertyToID("_ForwardScatteringG");
+        internal static readonly int _BackwardScatteringG = Shader.PropertyToID("_BackwardScatteringG");
+        internal static readonly int _DarkOutlineScalar = Shader.PropertyToID("_DarkOutlineScalar");
+        internal static readonly int _SunRayLength = Shader.PropertyToID("_SunRayLength");
+        internal static readonly int _ConeRadius = Shader.PropertyToID("_ConeRadius");
+        internal static readonly int _RayStepLength = Shader.PropertyToID("_RayStepLength");
+        internal static readonly int _Curl2D = Shader.PropertyToID("_Curl2D");
+        internal static readonly int _CoverageScale = Shader.PropertyToID("_CoverageScale");
+        internal static readonly int _CoverageOffset = Shader.PropertyToID("_CoverageOffset");
+        internal static readonly int _MaxRayDistance = Shader.PropertyToID("_MaxRayDistance");
+        internal static readonly int _Random0 = Shader.PropertyToID("_Random0");
+        internal static readonly int _Random1 = Shader.PropertyToID("_Random1");
+        internal static readonly int _Random2 = Shader.PropertyToID("_Random2");
+        internal static readonly int _Random3 = Shader.PropertyToID("_Random3");
+        internal static readonly int _Random4 = Shader.PropertyToID("_Random4");
+        internal static readonly int _Random5 = Shader.PropertyToID("_Random5");
+
+        internal static readonly int _MainTex = Shader.PropertyToID("_MainTex");
+        internal static readonly int _IsGamma = Shader.PropertyToID("_IsGamma");
+        internal static readonly int _SubFrame = Shader.PropertyToID("_SubFrame");
+        internal static readonly int _PrevFrame = Shader.PropertyToID("_PrevFrame");
+
+        internal static readonly int _EarthRadius = Shader.PropertyToID("_EarthRadius");
+        internal static readonly int _StartHeight = Shader.PropertyToID("_StartHeight");
+        internal static readonly int _EndHeight = Shader.PropertyToID("_EndHeight");
+        internal static readonly int _AtmosphereThickness = Shader.PropertyToID("_AtmosphereThickness");
+        internal static readonly int _CameraPosition = Shader.PropertyToID("_CameraPosition");
+        internal static readonly int _MaxDistance = Shader.PropertyToID("_MaxDistance");
+        internal static readonly int _PreviousProjection = Shader.PropertyToID("_PreviousProjection");
+        internal static readonly int _PreviousInverseProjection = Shader.PropertyToID("_PreviousInverseProjection");
+        internal static readonly int _PreviousRotation = Shader.PropertyToID("_PreviousRotation");
+        internal static readonly int _PreviousInverseRotation = Shader.PropertyToID("_PreviousInverseRotation");
+        internal static readonly int _Projection = Shader.PropertyToID("_Projection");
+        internal static readonly int _InverseProjection = Shader.PropertyToID("_InverseProjection");
+        internal static readonly int _Rotation = Shader.PropertyToID("_Rotation");
+        internal static readonly int _InverseRotation = Shader.PropertyToID("_InverseRotation");
+        internal static readonly int _SubFrameNumber = Shader.PropertyToID("_SubFrameNumber");
+        internal static readonly int _SubPixelSize = Shader.PropertyToID("_SubPixelSize");
+        internal static readonly int _SubFrameSize = Shader.PropertyToID("_SubFrameSize");
+        internal static readonly int _FrameSize = Shader.PropertyToID("_FrameSize");
+
+        internal static readonly int _Clouds = Shader.PropertyToID("_Clouds");
+        internal static readonly int _SunScreenSpace = Shader.PropertyToID("_SunScreenSpace");
+        internal static readonly int _SampleCount = Shader.PropertyToID("_SampleCount");
+        internal static readonly int _Decay = Shader.PropertyToID("_Decay");
+        internal static readonly int _Weight = Shader.PropertyToID("_Weight");
+        internal static readonly int _Exposure = Shader.PropertyToID("_Exposure");
+
+        internal static readonly int _CloudCoverage = Shader.PropertyToID("_CloudCoverage");
+        internal static readonly int _InvCamera = Shader.PropertyToID("_InvCamera");
+        internal static readonly int _InvProjection = Shader.PropertyToID("_InvProjection");
+        internal static readonly int _Offset = Shader.PropertyToID("_Offset");
+        internal static readonly int _ShadowStrength = Shader.PropertyToID("_ShadowStrength");
+
+        internal static readonly int _CoverageOpacity = Shader.PropertyToID("_CoverageOpacity");
+        internal static readonly int _TypeOpacity = Shader.PropertyToID("_TypeOpacity");
+        internal static readonly int _ShouldDrawCoverage = Shader.PropertyToID("_ShouldDrawCoverage");
+        internal static readonly int _ShouldDrawType = Shader.PropertyToID("_ShouldDrawType");
+        internal static readonly int _ShouldBlendValues = Shader.PropertyToID("_ShouldBlendValues");
+        internal static readonly int _BrushTexture = Shader.PropertyToID("_BrushTexture");
+        internal static readonly int _BrushTextureAlpha = Shader.PropertyToID("_BrushTextureAlpha");
+
+        internal static readonly int _SunSize = Shader.PropertyToID("_SunSize");
+    }
+}

--- a/Assets/kode80/Clouds/Scripts/Uniforms.cs.meta
+++ b/Assets/kode80/Clouds/Scripts/Uniforms.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bd806743a275031468fa6867bc002444
+timeCreated: 1479058677
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/kode80/Clouds/Scripts/kode80CloudShadows.cs
+++ b/Assets/kode80/Clouds/Scripts/kode80CloudShadows.cs
@@ -1,4 +1,4 @@
-﻿//***************************************************
+//***************************************************
 //
 //  Author: Ben Hopkins
 //  Copyright (C) 2016 kode80 LLC, 
@@ -15,7 +15,6 @@
 
 using UnityEngine;
 using UnityEngine.Rendering;
-using System.Collections;
 
 namespace kode80.Clouds
 {
@@ -27,11 +26,6 @@ namespace kode80.Clouds
         private Light _light;
         private CommandBuffer _commandBuffer;
         private Material _material;
-
-        void Start()
-        {
-
-        }
         
         void ShadowsPreCull( Camera camera)
         {
@@ -42,14 +36,14 @@ namespace kode80.Clouds
         {
             if( clouds == null || _light == null) { return; }
 
-            _material.SetTexture("_CloudCoverage", clouds.cloudCoverage);
-            _material.SetMatrix("_InvCamera", clouds.targetCamera.cameraToWorldMatrix);
-            _material.SetMatrix("_InvProjection", clouds.targetCamera.projectionMatrix.inverse);
-            _material.SetVector("_Offset", Vector3.zero);
-            _material.SetFloat("_CoverageScale", 1.0f / clouds.cloudsSharedProperties.maxDistance);
-            _material.SetVector("_CoverageOffset", clouds.coverageOffset);
-            _material.SetVector("_LightDirection", clouds.sunLight.transform.forward);
-            _material.SetFloat("_ShadowStrength", _light.shadowStrength);
+            _material.SetTexture(Uniforms._CloudCoverage, clouds.cloudCoverage);
+            _material.SetMatrix(Uniforms._InvCamera, clouds.targetCamera.cameraToWorldMatrix);
+            _material.SetMatrix(Uniforms._InvProjection, clouds.targetCamera.projectionMatrix.inverse);
+            _material.SetVector(Uniforms._Offset, Vector3.zero);
+            _material.SetFloat(Uniforms._CoverageScale, 1.0f / clouds.cloudsSharedProperties.maxDistance);
+            _material.SetVector(Uniforms._CoverageOffset, clouds.coverageOffset);
+            _material.SetVector(Uniforms._LightDirection, clouds.sunLight.transform.forward);
+            _material.SetFloat(Uniforms._ShadowStrength, _light.shadowStrength);
             clouds.cloudsSharedProperties.ApplyToMaterial(_material);
         }
 

--- a/Assets/kode80/Clouds/Scripts/kode80Clouds.cs
+++ b/Assets/kode80/Clouds/Scripts/kode80Clouds.cs
@@ -381,8 +381,8 @@ namespace kode80.Clouds
 				_isFirstFrame = false;
 			}
 			
-			_cloudCombinerMaterial.SetTexture( "_SubFrame", _subFrame);
-			_cloudCombinerMaterial.SetTexture( "_PrevFrame", _previousFrame);
+			_cloudCombinerMaterial.SetTexture(Uniforms._SubFrame, _subFrame);
+			_cloudCombinerMaterial.SetTexture(Uniforms._PrevFrame, _previousFrame);
 			_cloudsSharedProperties.ApplyToMaterial( _cloudCombinerMaterial);
 			
 			RenderTextureFormat format = _camera.hdr ? RenderTextureFormat.DefaultHDR : RenderTextureFormat.Default;
@@ -398,8 +398,8 @@ namespace kode80.Clouds
 
 			_cloudsSharedProperties.EndFrame();
 
-			_cloudBlenderMaterial.SetTexture( "_MainTex", currentFrame);
-			_cloudBlenderMaterial.SetInt( "_IsGamma", QualitySettings.activeColorSpace == ColorSpace.Gamma ? 1 : 0);
+			_cloudBlenderMaterial.SetTexture(Uniforms._MainTex, currentFrame);
+			_cloudBlenderMaterial.SetInt(Uniforms._IsGamma, QualitySettings.activeColorSpace == ColorSpace.Gamma ? 1 : 0);
 		}
         
         private Gradient CreateCloudGradient( float position0, float position1, float position2, float position3)
@@ -556,62 +556,61 @@ namespace kode80.Clouds
 			{
 				Vector3 lightDirection = sunLight.transform.forward;
 
-				_cloudMaterial.SetFloat( "_CloudBottomFade", cloudBottomFade);
+				_cloudMaterial.SetFloat(Uniforms._CloudBottomFade, cloudBottomFade);
 
-				_cloudMaterial.SetFloat( "_MaxIterations", maxIterations);
-				_cloudMaterial.SetFloat( "_SampleScalar", sampleScalar);
-				_cloudMaterial.SetFloat( "_SampleThreshold", sampleThreshold);
-				_cloudMaterial.SetFloat( "_LODDistance", lodDistance);
-                _cloudMaterial.SetFloat("_RayMinimumY", horizonLevel);
-                _cloudMaterial.SetFloat( "_DetailScale", detailScale);
-				_cloudMaterial.SetFloat( "_ErosionEdgeSize", erosionEdgeSize);
-				_cloudMaterial.SetFloat( "_CloudDistortion", cloudDistortion);
-				_cloudMaterial.SetFloat( "_CloudDistortionScale", cloudDistortionScale);
-				_cloudMaterial.SetFloat( "_HorizonFadeScalar", horizonFade);
-                _cloudMaterial.SetFloat("_HorizonFadeStartAlpha", horizonFadeStartAlpha);
-                _cloudMaterial.SetFloat("_OneMinusHorizonFadeStartAlpha", 1.0f - horizonFadeStartAlpha);
-                _cloudMaterial.SetTexture( "_Perlin3D", _perlin3D);
-				_cloudMaterial.SetTexture( "_Detail3D", _detail3D);
-				_cloudMaterial.SetVector( "_BaseOffset", _baseOffset);
-				_cloudMaterial.SetVector( "_DetailOffset", _detailOffset);
-				_cloudMaterial.SetFloat( "_BaseScale", 1.0f / atmosphereEndHeight * baseScale);
-				_cloudMaterial.SetFloat( "_LightScalar", sunScalar);
-				_cloudMaterial.SetFloat( "_AmbientScalar", ambientScalar);
-				_cloudMaterial.SetVector( "_CloudHeightGradient1", _cloudGradientVector1);
-				_cloudMaterial.SetVector( "_CloudHeightGradient2", _cloudGradientVector2);
-				_cloudMaterial.SetVector( "_CloudHeightGradient3", _cloudGradientVector3);
-				_cloudMaterial.SetTexture( "_Coverage", cloudCoverage);
-				_cloudMaterial.SetVector( "_LightDirection", lightDirection);
+				_cloudMaterial.SetFloat(Uniforms._MaxIterations, maxIterations);
+				_cloudMaterial.SetFloat(Uniforms._SampleScalar, sampleScalar);
+				_cloudMaterial.SetFloat(Uniforms._SampleThreshold, sampleThreshold);
+				_cloudMaterial.SetFloat(Uniforms._LODDistance, lodDistance);
+				_cloudMaterial.SetFloat(Uniforms._RayMinimumY, horizonLevel);
+				_cloudMaterial.SetFloat(Uniforms._DetailScale, detailScale);
+				_cloudMaterial.SetFloat(Uniforms._ErosionEdgeSize, erosionEdgeSize);
+				_cloudMaterial.SetFloat(Uniforms._CloudDistortion, cloudDistortion);
+				_cloudMaterial.SetFloat(Uniforms._CloudDistortionScale, cloudDistortionScale);
+				_cloudMaterial.SetFloat(Uniforms._HorizonFadeScalar, horizonFade);
+				_cloudMaterial.SetFloat(Uniforms._HorizonFadeStartAlpha, horizonFadeStartAlpha);
+				_cloudMaterial.SetFloat(Uniforms._OneMinusHorizonFadeStartAlpha, 1.0f - horizonFadeStartAlpha);
+				_cloudMaterial.SetTexture(Uniforms._Perlin3D, _perlin3D);
+				_cloudMaterial.SetTexture(Uniforms._Detail3D, _detail3D);
+				_cloudMaterial.SetVector(Uniforms._BaseOffset, _baseOffset);
+				_cloudMaterial.SetVector(Uniforms._DetailOffset, _detailOffset);
+				_cloudMaterial.SetFloat(Uniforms._BaseScale, 1.0f / atmosphereEndHeight * baseScale);
+				_cloudMaterial.SetFloat(Uniforms._LightScalar, sunScalar);
+				_cloudMaterial.SetFloat(Uniforms._AmbientScalar, ambientScalar);
+				_cloudMaterial.SetVector(Uniforms._CloudHeightGradient1, _cloudGradientVector1);
+				_cloudMaterial.SetVector(Uniforms._CloudHeightGradient2, _cloudGradientVector2);
+				_cloudMaterial.SetVector(Uniforms._CloudHeightGradient3, _cloudGradientVector3);
+				_cloudMaterial.SetTexture(Uniforms._Coverage, cloudCoverage);
+				_cloudMaterial.SetVector(Uniforms._LightDirection, lightDirection);
 
-				_cloudMaterial.SetColor( "_LightColor", sunLight.color);
-				_cloudMaterial.SetColor( "_CloudBaseColor", cloudBaseColor);
-				_cloudMaterial.SetColor( "_CloudTopColor", cloudTopColor);
+				_cloudMaterial.SetColor(Uniforms._LightColor, sunLight.color);
+				_cloudMaterial.SetColor(Uniforms._CloudBaseColor, cloudBaseColor);
+				_cloudMaterial.SetColor(Uniforms._CloudTopColor, cloudTopColor);
 
-				_cloudMaterial.SetFloat( "_HorizonCoverageStart", horizonCoverageStart);
-				_cloudMaterial.SetFloat( "_HorizonCoverageEnd", horizonCoverageEnd);
+				_cloudMaterial.SetFloat(Uniforms._HorizonCoverageStart, horizonCoverageStart);
+				_cloudMaterial.SetFloat(Uniforms._HorizonCoverageEnd, horizonCoverageEnd);
 
-					
-				_cloudMaterial.SetFloat( "_Density", density);
-				_cloudMaterial.SetFloat( "_ForwardScatteringG", forwardScatteringG);
-				_cloudMaterial.SetFloat( "_BackwardScatteringG", backwardScatteringG);
-				_cloudMaterial.SetFloat( "_DarkOutlineScalar", darkOutlineScalar);
+				_cloudMaterial.SetFloat(Uniforms._Density, density);
+				_cloudMaterial.SetFloat(Uniforms._ForwardScatteringG, forwardScatteringG);
+				_cloudMaterial.SetFloat(Uniforms._BackwardScatteringG, backwardScatteringG);
+				_cloudMaterial.SetFloat(Uniforms._DarkOutlineScalar, darkOutlineScalar);
 
-                float atmosphereThickness = atmosphereEndHeight - atmosphereStartHeight;
-                _cloudMaterial.SetFloat( "_SunRayLength", sunRayLength * atmosphereThickness);
-				_cloudMaterial.SetFloat( "_ConeRadius", coneRadius * atmosphereThickness);
-                _cloudMaterial.SetFloat( "_RayStepLength", atmosphereThickness / Mathf.Floor(maxIterations / 2.0f));
+				float atmosphereThickness = atmosphereEndHeight - atmosphereStartHeight;
+				_cloudMaterial.SetFloat(Uniforms._SunRayLength, sunRayLength * atmosphereThickness);
+				_cloudMaterial.SetFloat(Uniforms._ConeRadius, coneRadius * atmosphereThickness);
+				_cloudMaterial.SetFloat(Uniforms._RayStepLength, atmosphereThickness / Mathf.Floor(maxIterations / 2.0f));
 
-                _cloudMaterial.SetTexture( "_Curl2D", _curlTexture);
-				_cloudMaterial.SetFloat( "_CoverageScale", 1.0f / _cloudsSharedProperties.maxDistance);
-				_cloudMaterial.SetVector( "_CoverageOffset", _coverageOffset);
-				_cloudMaterial.SetFloat( "_MaxRayDistance", _cloudsSharedProperties.maxRayDistance);
-                
-				_cloudMaterial.SetVector( "_Random0", _randomVectors[0]);
-				_cloudMaterial.SetVector( "_Random1", _randomVectors[1]);
-				_cloudMaterial.SetVector( "_Random2", _randomVectors[2]);
-				_cloudMaterial.SetVector( "_Random3", _randomVectors[3]);
-				_cloudMaterial.SetVector( "_Random4", _randomVectors[4]);
-				_cloudMaterial.SetVector( "_Random5", _randomVectors[5]);
+				_cloudMaterial.SetTexture(Uniforms._Curl2D, _curlTexture);
+				_cloudMaterial.SetFloat(Uniforms._CoverageScale, 1.0f / _cloudsSharedProperties.maxDistance);
+				_cloudMaterial.SetVector(Uniforms._CoverageOffset, _coverageOffset);
+				_cloudMaterial.SetFloat(Uniforms._MaxRayDistance, _cloudsSharedProperties.maxRayDistance);
+
+				_cloudMaterial.SetVector(Uniforms._Random0, _randomVectors[0]);
+				_cloudMaterial.SetVector(Uniforms._Random1, _randomVectors[1]);
+				_cloudMaterial.SetVector(Uniforms._Random2, _randomVectors[2]);
+				_cloudMaterial.SetVector(Uniforms._Random3, _randomVectors[3]);
+				_cloudMaterial.SetVector(Uniforms._Random4, _randomVectors[4]);
+				_cloudMaterial.SetVector(Uniforms._Random5, _randomVectors[5]);
 			}
 		}
 


### PR DESCRIPTION
The `FullScreenQuad` class was generating garbage on every frame, it's now fixed.

More importantly, this PR optimizes material usage. Every time you do a `material.SetXXX(string, value);` it will internally compute a hash for the name and do a lookup. Considering the amount of uniforms sent on every frame in this asset... It can quickly become expensive on slower CPUs. So no need to do it on every frame, it should only be done once and reused :)

Every little bit helps... Uniforms should be tightly packed together (e.g. put 4 `float` in a `float4`) to optimize this even more but for now that'll do.